### PR TITLE
Bug fix/back button behaviour

### DIFF
--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
@@ -109,7 +109,7 @@ public class FullscreenActivity extends AppCompatActivity {
 
             boolean IS_DEBUG = 0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE);
 
-            jsi = new JavaScriptInterface(this, wv, IS_DEBUG);
+            jsi = new JavaScriptInterface(this, wv);
             wv.addJavascriptInterface(jsi, "SUPAndroid");
 
             if (BuildConfig.FLAVOR.equals("fdroid")) {

--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
@@ -158,4 +158,13 @@ public class FullscreenActivity extends AppCompatActivity {
             }
         });
     }
+
+    @Override
+    public void onBackPressed() {
+        if (wv.canGoBack()) {
+            wv.goBack();
+        } else {
+            super.onBackPressed();
+        }
+    }
 }


### PR DESCRIPTION
# Description

Captures back button taps when `FullscreenActivity` is the current `Activity` and checks if the `WebView` has a back history item. If it does, the `WebView` performs the back navigation otherwise the back press is delegated to the Activity.

## Issues Resolved

Fixes #6 

## Check List

- [ ] New functionality includes testing. - **Not included as we would only be testing the framework**
- [ ] New functionality has been documented in the README if applicable. **N/A**
