### PR TITLE
Fix build error due to wrong parameter

### DIFF
--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.java
@@ -52,7 +52,7 @@ public class FullscreenActivity extends AppCompatActivity {
         frameLayout.addView(wv);
 
         // init JS here, as it needs an activity to work
-        jsi = new JavaScriptInterface(this, wv, IS_DEBUG);
+        jsi = new JavaScriptInterface(this, wv);
         wv.addJavascriptInterface(jsi, INTERFACE_PROPERTY);
         if (BuildConfig.FLAVOR.equals("fdroid")) {
             wv.addJavascriptInterface(jsi, INTERFACE_PROPERTY_F_DROID);


### PR DESCRIPTION
# Description

`JavaScriptInterface` was receiving one more parameter when its constructor only accepts 2, to fix build this PR remove the unused parameter

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
