### PR TITLE
re-implement file sync feature with scoped permissions via SimpleStorage library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation "com.google.androidbrowserhelper:androidbrowserhelper:2.4.0"
     implementation "com.google.code.gson:gson:2.10"
     implementation "androidx.core:core-ktx:1.9.0"
+    implementation "com.anggrayudi:storage:1.5.4"
 
     playImplementation "com.google.android.gms:play-services-auth:20.4.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".App"

--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
@@ -10,6 +10,7 @@ import android.webkit.*
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.anggrayudi.storage.SimpleStorageHelper
 
 /**
  * An example full-screen activity that shows and hides the system UI (i.e.
@@ -20,6 +21,7 @@ class FullscreenActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private lateinit var wvContainer: FrameLayout
     var isInForeground: Boolean = false
+    val storageHelper = SimpleStorageHelper(this) // for scoped storage permission management on Android 10+
 
     @Suppress("ReplaceCallWithBinaryOperator")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -79,7 +81,8 @@ class FullscreenActivity : AppCompatActivity() {
         if (BuildConfig.DEBUG) {
 //            url = "https://app.super-productivity.com"
             // for debugging locally run web server
-            url = "http://10.0.2.2:4200"
+            //url = "http://10.0.2.2:4200"
+            url = "https://app.super-productivity.com"
             Toast.makeText(this, "DEBUG: $url", Toast.LENGTH_SHORT).show()
             webView.clearCache(true)
             webView.clearHistory()
@@ -203,5 +206,24 @@ class FullscreenActivity : AppCompatActivity() {
     companion object {
         const val WINDOW_INTERFACE_PROPERTY: String = "SUPAndroid"
         const val WINDOW_PROPERTY_F_DROID: String = "SUPFDroid"
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        // Save scoped storage permission on Android 10+
+        storageHelper.onSaveInstanceState(outState)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        // Restore scoped storage permission on Android 10+
+        super.onRestoreInstanceState(savedInstanceState)
+        storageHelper.onRestoreInstanceState(savedInstanceState)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        // Restore scoped storage permission on Android 10+
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        // Mandatory for Activity, but not for Fragment & ComponentActivity
+        storageHelper.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }


### PR DESCRIPTION
# Description
Re-implements PR #25 without requiring `MANAGE_EXTERNAL_STORAGE` permission, which is asks for permission to write ALL files on the Android device and which is rejected by the Google Play Store rules for all apps except those that really require it (such as file managers).

With this PR here, there is no need for special permissions anymore, the app asks for permission to write in a single folder. In fact we could rewrite to ask to write only in a single file, but having permission over a whole folder allows to write more files if there is a need in the future.

To test, there is a debug APK here: https://github.com/lrq3000/super-productivity-android/releases/tag/super-productivity-android_scoped-storage

## Issues Resolved
Fixes #31, fixes #13.

Can also be used as a workaround for #9.

The library that is managing permissions, SimpleStorage, can also be used to implement #8.

## Check List
- [x] Functionality appears to work for me.
- [ ] Can others try and report if it works for them too?
