### PR TITLE
Scoped storage bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ I am not an Android developer, so help would be very welcome!!
 
 For building this app locally you have two options for loading the web view:
 1. Pointing to "https://app.super-productivity.com", Which is what the app currently does in production mode, Then you only can edit and see the changes you make on android app part.
-2. Running [super productivity](https://github.com/johannesjo/super-productivity) app locally and point the web view to load that address, So you can see the changes you have made.
+2. Running [super productivity](https://github.com/johannesjo/super-productivity) app locally and point the web view to load that address, So you can see the changes you have made. To make the local web app accessible from inside the Android Studio emulator, run the web app using `ng serve --disable-host-check --host 0.0.0.0 --port 4200 --live-reload --watch` (note the `--host 0.0.0.0`, this is necessary otherwise the web app won't be reachable). Then, inside the Android app's code, simply point to `http://10.0.2.2:4200` (the URL should also work in the emulator's Chrome browser).
 
 You can edit the url that the web view loads in "App.java" file [here](https://github.com/johannesjo/super-productivity-android/blob/master/app/src/main/java/com/superproductivity/superproductivity/App.java#L33-L36).

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -339,7 +339,7 @@ abstract class CommonJavaScriptInterface(
             // Build fullFilePath from folder path and filepath
             val fullFilePath = "$folderPath/$filePath"
             // Load file
-            val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess = false)
+            val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=false)
             // Get last modified date
             val lastModif = file?.lastModified().toString()
             Log.d("SuperProductivity", "getFileRev lastModified: $lastModif")

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -508,7 +508,7 @@ abstract class CommonJavaScriptInterface(
                     sp.edit().putString("filesyncFolder", fpath).apply()
                     // Once permissions are granted, callback web application to continue execution
                     callJavaScriptFunction(
-                        FN_PREFIX + "grantFilePermissionCallBack('" + requestCode + "')"
+                        FN_PREFIX + "grantFilePermissionCallBack('" + requestId + "')"
                     )
                 }
             // Open folder picker via SimpleStorage, this will request the necessary scoped storage permission

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -436,6 +436,41 @@ abstract class CommonJavaScriptInterface(
 
     @Suppress("unused")
     @JavascriptInterface
+    fun allowedFolderPath(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val grantedPaths = DocumentFileCompat.getAccessibleAbsolutePaths(activity)
+            Log.d("SuperProductivity", "allowedFolderPath grantedPaths: " + grantedPaths.toString())
+            val sp = activity.getPreferences(Context.MODE_PRIVATE)
+            val folderPath = sp.getString("filesyncFolder", "") ?: ""
+            Log.d("SuperProductivity", "allowedFolderPath filesyncFolder: $folderPath")
+
+            // Check if stored path is in the list of granted path, if true, then return it, else return an empty string
+            val vpaths: List<String> = grantedPaths.values.toList().flatten()
+            Log.d("SuperProductivity", "allowedFolderPath flattened values: " + vpaths.toString())
+            if (folderPath.isNotEmpty() && grantedPaths.isNotEmpty() && vpaths.contains(folderPath)) {
+                return folderPath
+            } else {
+                return ""
+            }
+        } else {
+            val result = ContextCompat.checkSelfPermission(
+                activity, Manifest.permission.READ_EXTERNAL_STORAGE
+            )
+            val result1 = ContextCompat.checkSelfPermission(
+                activity, Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+
+            // For older versions of Android, check if we have access to any folder, then return "<any>" otherwise return an empty string
+            if ((result == PackageManager.PERMISSION_GRANTED) && (result1 == PackageManager.PERMISSION_GRANTED)) {
+                return "<any>"
+            } else {
+                return ""
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
     fun isGrantedFilePermission(): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val grantedPaths = DocumentFileCompat.getAccessibleAbsolutePaths(activity)
         Log.d("SuperProductivity", "isGrantedFilePermission grantedPaths: " + grantedPaths.toString())

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -380,18 +380,15 @@ abstract class CommonJavaScriptInterface(
                 ""
             } else {
                 // Read input file
-                val lines: List<String> =
-                    try {
-                        reader.readLines()
-                    } catch (e: Exception) {
-                        Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
-                        // Return an empty list if there is an error (maybe file does not exist yet)
-                        emptyList()
-                    } finally {
-                        reader.close()
-                    }
-                // Rebuild input file's content but replacing line returns with current OS's line return character
-                lines.joinToString(System.getProperty("line.separator"))
+                try {
+                    reader.readText()
+                } catch (e: Exception) {
+                    Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
+                    // Return an empty string if there is an error (maybe file does not exist yet)
+                    ""
+                } finally {
+                    reader.close()
+                }
             }
         // Return file's content
         return sb

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -353,7 +353,10 @@ abstract class CommonJavaScriptInterface(
     @Suppress("unused")
     @JavascriptInterface
     fun readFile(filePath: String): String {
+        // Read a file, most likely the filesync database
         Log.d("SuperProductivity", "readFile")
+        
+        // Make a reader pointing to the input file
         val reader =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // Scoped storage permission management for Android 10+
@@ -369,25 +372,32 @@ abstract class CommonJavaScriptInterface(
             } else {
                 BufferedReader(FileReader(filePath))
             }
-        val sb = StringBuilder()
 
+        // Use a StringBuilder to rebuild the input file's content but replace the line returns with current OS's line returns
+        val sb = StringBuilder()
         if (reader == null) {
             Log.d("SuperProductivity", "readFile warning: tried to open file, but file does not exist or we do not have permission! This may be normal if file does not exist yet, it will be created when some tasks will be added.")
         } else {
-            try {
-                val lines: List<String> = reader.readLines()
-                val ls = System.getProperty("line.separator")
-                for (line in lines) {
-                    sb.append(line)
-                    sb.append(ls)
+            // Read input file
+            val lines: List<String> =
+                try {
+                    reader.readLines()
+                } catch (e: Exception) {
+                    Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
+                    // Return an empty list if there is an error (maybe file does not exist yet)
+                    emptyList()
+                } finally {
+                    reader.close()
                 }
-                sb.deleteCharAt(sb.length - 1)
-            } catch (e: Exception) {
-                Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
-            } finally {
-                reader.close()
+            // Get current OS's line return character
+            val ls = System.getProperty("line.separator")
+            // Rebuild input file's content but replacing line returns
+            for (line in lines) {
+                sb.append(line)
+                sb.append(ls)
             }
         }
+        // Return file content
         return sb.toString()
     }
 

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -374,31 +374,27 @@ abstract class CommonJavaScriptInterface(
             }
 
         // Use a StringBuilder to rebuild the input file's content but replace the line returns with current OS's line returns
-        val sb = StringBuilder()
-        if (reader == null) {
-            Log.d("SuperProductivity", "readFile warning: tried to open file, but file does not exist or we do not have permission! This may be normal if file does not exist yet, it will be created when some tasks will be added.")
-        } else {
-            // Read input file
-            val lines: List<String> =
-                try {
-                    reader.readLines()
-                } catch (e: Exception) {
-                    Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
-                    // Return an empty list if there is an error (maybe file does not exist yet)
-                    emptyList()
-                } finally {
-                    reader.close()
-                }
-            // Get current OS's line return character
-            val ls = System.getProperty("line.separator")
-            // Rebuild input file's content but replacing line returns
-            for (line in lines) {
-                sb.append(line)
-                sb.append(ls)
+        val sb: String =
+            if (reader == null) {
+                Log.d("SuperProductivity", "readFile warning: tried to open file, but file does not exist or we do not have permission! This may be normal if file does not exist yet, it will be created when some tasks will be added.")
+                ""
+            } else {
+                // Read input file
+                val lines: List<String> =
+                    try {
+                        reader.readLines()
+                    } catch (e: Exception) {
+                        Log.d("SuperProductivity", "readFile error: " + e.stackTraceToString())
+                        // Return an empty list if there is an error (maybe file does not exist yet)
+                        emptyList()
+                    } finally {
+                        reader.close()
+                    }
+                // Rebuild input file's content but replacing line returns with current OS's line return character
+                lines.joinToString(System.getProperty("line.separator"))
             }
-        }
-        // Return file content
-        return sb.toString()
+        // Return file's content
+        return sb
     }
 
     @Suppress("unused")

--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
@@ -79,10 +79,9 @@ class FullscreenActivity : AppCompatActivity() {
         webView = (application as App).wv
         val url: String
         if (BuildConfig.DEBUG) {
-//            url = "https://app.super-productivity.com"
+            //url = "https://app.super-productivity.com"
             // for debugging locally run web server
-            //url = "http://10.0.2.2:4200"
-            url = "https://app.super-productivity.com"
+            url = "http://10.0.2.2:4200"
             Toast.makeText(this, "DEBUG: $url", Toast.LENGTH_SHORT).show()
             webView.clearCache(true)
             webView.clearHistory()

--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
@@ -224,6 +224,6 @@ class FullscreenActivity : AppCompatActivity() {
         // Restore scoped storage permission on Android 10+
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         // Mandatory for Activity, but not for Fragment & ComponentActivity
-        storageHelper.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        //storageHelper.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -6,8 +6,10 @@
             <certificates src="user"
                 tools:ignore="AcceptsUserCertificates" />
             <certificates src="system" />
-
         </trust-anchors>
-
     </base-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
# Description

Fix residual issues after PR #32 merge:
* Read and write of filesync file now works as intended (before it always looked for a "filePath" file, instead of the path pointed by the `$filePath` variable). In the previous PR, without the bugfix, the user's specified filePath was respected the first time, on file creation, but afterwards the file was not updated nor read.
* Calls `grantFilePermissionCallBack()` after folder is picked and permission is granted. ~Web app needs an update too to call `isGrantedFilePermission()` only after the requestId `rId` is deleted from `requestMap` in `grantFilePermissionCallBack()`, as discussed in more details here: https://github.com/johannesjo/super-productivity-android/pull/32#issuecomment-1382965427 .~
* Implements `allowedFolderPath()` to display in the UI the currently granted path to avoid user confusion (@zoli's sugestion).
* A few bugfixes here and there for edge cases, especially in `readFile()`.
* Updated README.md instructions to access local webserver from Android emulator.

A debug APK is available here: ~https://github.com/lrq3000/super-productivity-android/releases/tag/super-productivity-android_scoped-storage_bugfix1~ ~https://github.com/lrq3000/super-productivity-android/releases/tag/super-productivity-android_scoped-storage_bugfix2~ https://github.com/lrq3000/super-productivity-android/releases/tag/super-productivity-android_scoped-storage_bugfix3

## Issues Resolved

Fixes #13 (again 😅), fixes https://github.com/johannesjo/super-productivity/issues/2001 , fixes https://github.com/johannesjo/super-productivity/issues/690 .

## Check List

- [x] ~Web app update to check `isGrantedFilePermission()` after `grantFilePermissionCallBack()`. Until then, the app must be killed and relaunched after folder selection, or the folder needs to be selected twice, to force the app to query again the permissions and hence be able to Enable Syncing (otherwise we get a "Needs permission" warning message).~ Fixed `requestCode` into `requestId` in `grantFilePermissionCallBack()` and it now works fine!
- [x] Implement `allowedFolderPath()` to display in the UI the currently granted path to avoid user confusion (@zoli's sugestion).
- [x] Tested bidirectional syncing myself (via Syncthing-Fork on Android + Synctrayzor on Windows 10).
- [x] Someone else needs to test too.
