### PR TITLE
Filesync compatibility with Android <= 9 (fixes #36) + critical bugfixes for Android <= 7.1.1 and 13

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/androidTest/java/com/superproductivity/superproductivity/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/superproductivity/superproductivity/ExampleInstrumentedTest.java
@@ -1,13 +1,14 @@
 package com.superproductivity.superproductivity;
 
+import static org.junit.Assert.assertEquals;
+
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.*;
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -375,7 +375,12 @@ abstract class CommonJavaScriptInterface(
                 file?.openInputStream(activity)?.reader()
             } else {
                 // Older versions of Android <= 9 don't need scoped storage management
-                BufferedReader(FileReader(fullFilePath))
+                try {
+                    BufferedReader(FileReader(fullFilePath))
+                } catch (e: Exception) {
+                    // File does not exist, that's normal if it's the first time, we simply return null
+                    null
+                }
             }
 
         // Use a StringBuilder to rebuild the input file's content but replace the line returns with current OS's line returns
@@ -494,6 +499,7 @@ abstract class CommonJavaScriptInterface(
     @JavascriptInterface
     fun grantFilePermission(requestId: String) {
         // For Android < 10, ask for permission to access the whole storage
+        /* DEPRECATED: if we use this to get the permissions, then we need to use another folder picker than SimpleStorage, because otherwise SimpleStorage also asks for permissions, but Android does not accept asking for two different set of permissions in a single call: "Can reqeust only one set of permissions at a time"
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             ActivityCompat.requestPermissions(
                 activity, arrayOf(
@@ -502,6 +508,7 @@ abstract class CommonJavaScriptInterface(
                 ), 1
             )
         }
+        */
         // For Android >= 10, use scoped storage via SimpleStorage library to get the permission to write files in a folder
         // For Android < 10, SimpleStorage serves as a simple folder path picker, so that we still save where the user want look for a database file
         // Note that SimpleStorage takes care of all the gritty technical details, including whether the user must pick a root path BEFORE selecting the folder they want to store in, everything is explained to the user

--- a/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/CommonJavaScriptInterface.kt
@@ -57,12 +57,6 @@ abstract class CommonJavaScriptInterface(
         // Mandatory for Activity, but not for Fragment & ComponentActivity
         Log.d("SuperProductivity", "onActivityResult")
         activity.storageHelper.storage.onActivityResult(requestCode, resultCode, data)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            // Once permissions are granted, callback web application to continue execution
-            callJavaScriptFunction(
-                FN_PREFIX + "grantFilePermissionCallBack('" + requestCode + "')"
-            )
-        }
     }
 
     @Suppress("unused")
@@ -331,13 +325,13 @@ abstract class CommonJavaScriptInterface(
     @JavascriptInterface
     fun getFileRev(filePath: String): String {
         Log.d("SuperProductivity", "getFileRev")
+        // Get folder path
+        val sp = activity.getPreferences(Context.MODE_PRIVATE)
+        val folderPath = sp.getString("filesyncFolder", "") ?: ""
+        // Build fullFilePath from folder path and filepath
+        val fullFilePath = "$folderPath/$filePath"
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             // Scoped storage permission management for Android 10+
-            // Get folder path
-            val sp = activity.getPreferences(Context.MODE_PRIVATE)
-            val folderPath = sp.getString("filesyncFolder", "") ?: ""
-            // Build fullFilePath from folder path and filepath
-            val fullFilePath = "$folderPath/$filePath"
             // Load file
             val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=false)
             // Get last modified date
@@ -345,8 +339,11 @@ abstract class CommonJavaScriptInterface(
             Log.d("SuperProductivity", "getFileRev lastModified: $lastModif")
             lastModif
         } else {
-            val file = File(filePath)
-            file.lastModified().toString()
+            val file = File(fullFilePath)
+            // Get last modified date
+            val lastModif = file.lastModified().toString()
+            Log.d("SuperProductivity", "getFileRev lastModified: $lastModif")
+            lastModif
         }
     }
 
@@ -355,22 +352,30 @@ abstract class CommonJavaScriptInterface(
     fun readFile(filePath: String): String {
         // Read a file, most likely the filesync database
         Log.d("SuperProductivity", "readFile")
-        
+
+        // Get folder path
+        val sp = activity.getPreferences(Context.MODE_PRIVATE)
+        val folderPath = sp.getString("filesyncFolder", "") ?: ""
+        // Build fullFilePath from folder path and filepath
+        val fullFilePath = "$folderPath/$filePath"
+        Log.d(
+            "SuperProductivity",
+            "readFile: trying to read from fullFilePath: " + fullFilePath
+        )
+        // Open file in read only mode and an InputStream
         // Make a reader pointing to the input file
         val reader =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // Scoped storage permission management for Android 10+
-                // Get folder path
-                val sp = activity.getPreferences(Context.MODE_PRIVATE)
-                val folderPath = sp.getString("filesyncFolder", "") ?: ""
-                // Build fullFilePath from folder path and filepath
-                val fullFilePath = "$folderPath/$filePath"
-                Log.d("SuperProductivity", "readFile: trying to read from fullFilePath: " + fullFilePath)
-                // Open file in read only mode and an InputStream
-                val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=false)
+                val file = DocumentFileCompat.fromFullPath(
+                    activity,
+                    fullFilePath,
+                    requiresWriteAccess = false
+                )
                 file?.openInputStream(activity)?.reader()
             } else {
-                BufferedReader(FileReader(filePath))
+                // Older versions of Android <= 9 don't need scoped storage management
+                BufferedReader(FileReader(fullFilePath))
             }
 
         // Use a StringBuilder to rebuild the input file's content but replace the line returns with current OS's line returns
@@ -397,34 +402,29 @@ abstract class CommonJavaScriptInterface(
     @Suppress("unused")
     @JavascriptInterface
     fun writeFile(filePath: String, data: String) {
-        val writer: Writer =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // Scoped storage permission management for Android 10+
-                Log.d("SuperProductivity", "writeFile: trying to save to filePath: " + filePath)
-                // Get folder path
-                val sp = activity.getPreferences(Context.MODE_PRIVATE)
-                val folderPath = sp.getString("filesyncFolder", "") ?: ""
-                // Build fullFilePath from folder path and filepath
-                val fullFilePath = "$folderPath/$filePath"
-                Log.d("SuperProductivity", "writeFile: trying to save to fullFilePath: " + fullFilePath)
-                // Open file with write access, using SimpleStorage helper wrapper DocumentFileCompat
-                var file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=true, considerRawFile=true)
-                if ((file == null) || (!file.exists())) {  // if file does not exist, we create it
-                    Log.d("SuperProductivity", "writeFile: file does not exist, try to create it")
-                    val folder = DocumentFileCompat.fromFullPath(activity, folderPath, requiresWriteAccess=true)
-                    Log.d("SuperProductivity", "writeFile: do we have access to parentFolder? " + folder.toString())
-                    file = folder!!.makeFile(activity, filePath, mode=CreateMode.REPLACE) // do NOT specify a mimeType, otherwise Android will force a file extension
-                }
-                Log.d("SuperProductivity", "writeFile: erase file content by recreating it")
-                file = file?.recreateFile(activity)  // erase content first by recreating file. For some reason, DocumentFileCompat.fromFullPath(requiresWriteAccess=true) and openOutputStream(append=false) only open the file in append mode, so we need to recreate the file to truncate its content first
-                // Open an OutputStream to the file without append mode (so we write from the start of the file)
-                Log.d("SuperProductivity", "writeFile: try to openOutputStream")
-                file?.openOutputStream(activity, append=false)!!.writer()
-            } else {
-                BufferedWriter(FileWriter(filePath))
+            Log.d("SuperProductivity", "writeFile: trying to save to filePath: " + filePath)
+            // Get folder path
+            val sp = activity.getPreferences(Context.MODE_PRIVATE)
+            val folderPath = sp.getString("filesyncFolder", "") ?: ""
+            // Build fullFilePath from folder path and filepath
+            val fullFilePath = "$folderPath/$filePath"
+            Log.d("SuperProductivity", "writeFile: trying to save to fullFilePath: " + fullFilePath)
+            // Scoped storage permission management for Android 10+, but also works for Android < 10
+            // Open file with write access, using SimpleStorage helper wrapper DocumentFileCompat
+            var file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=true, considerRawFile=true)
+            if ((file == null) || (!file.exists())) {  // if file does not exist, we create it
+                Log.d("SuperProductivity", "writeFile: file does not exist, try to create it")
+                val folder = DocumentFileCompat.fromFullPath(activity, folderPath, requiresWriteAccess=true)
+                Log.d("SuperProductivity", "writeFile: do we have access to parentFolder? " + folder.toString())
+                file = folder!!.makeFile(activity, filePath, mode=CreateMode.REPLACE) // do NOT specify a mimeType, otherwise Android will force a file extension
             }
+            Log.d("SuperProductivity", "writeFile: erase file content by recreating it")
+            file = file?.recreateFile(activity)  // erase content first by recreating file. For some reason, DocumentFileCompat.fromFullPath(requiresWriteAccess=true) and openOutputStream(append=false) only open the file in append mode, so we need to recreate the file to truncate its content first
+            // Open a writer to an OutputStream to the file without append mode (so we write from the start of the file)
+            Log.d("SuperProductivity", "writeFile: try to openOutputStream")
+            val writer: Writer =file?.openOutputStream(activity, append=false)!!.writer()
         try {
-            Log.d("SuperProductivity", "writeFile: try to write data into file: " + data)
+            Log.d("SuperProductivity", "writeFile: try to write data into file: $data")
             writer.write(data)
             Log.d("SuperProductivity", "writeFile: write apparently successful!")
         } catch (e: Exception) {
@@ -493,39 +493,8 @@ abstract class CommonJavaScriptInterface(
     @Suppress("unused")
     @JavascriptInterface
     fun grantFilePermission(requestId: String) {
-        // For Android >= 10, use scoped storage via SimpleStorage library to get the permission to write files in a folder
-        // Note that SimpleStorage takes care of all the gritty technical details, including whether the user must pick a root path BEFORE selecting the folder they want to store in, everything is explained to the user
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            Log.d("SuperProductivity", "Before SimpleStorageHelper callback func def")
-            // Register a callback with SimpleStorage when a folder is picked
-            activity.storageHelper.onFolderSelected =
-                { requestCode, root -> // could also use simpleStorageHelper.onStorageAccessGranted()
-                    Log.d("SuperProductivity", "Success Folder Pick! Now saving...")
-                    // Get absolute path to folder
-                    val fpath = root.getAbsolutePath(activity)
-                    // Open preferences to save folder to path
-                    val sp = activity.getPreferences(Context.MODE_PRIVATE)
-                    sp.edit().putString("filesyncFolder", fpath).apply()
-                    // Once permissions are granted, callback web application to continue execution
-                    callJavaScriptFunction(
-                        FN_PREFIX + "grantFilePermissionCallBack('" + requestId + "')"
-                    )
-                }
-            // Open folder picker via SimpleStorage, this will request the necessary scoped storage permission
-            // Note that even though we get permissions, we need to only write DocumentFile files, not MediaStore files, because the latter are not meant to be reopened in the future so we can lose permission at anytime once they are written once, see: https://github.com/anggrayudi/SimpleStorage/issues/103
-            Log.d("SuperProductivity", "Get Storage Access permission")
-            activity.storageHelper.openFolderPicker(
-                // We could also use simpleStorageHelper.requestStorageAccess()
-                initialPath = FileFullPath(
-                    activity,
-                    StorageId.PRIMARY,
-                    "SupProd"
-                ), // SimpleStorage.externalStoragePath if we want to default to sdcard
-                // to force pick a specific folder and none others, use these arguments for simpleStorageHelper.requestStorageAccess():
-                //expectedStorageType = StorageType.EXTERNAL,
-                //expectedBasePath = "SupProd"
-            )
-        } else {
+        // For Android < 10, ask for permission to access the whole storage
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             ActivityCompat.requestPermissions(
                 activity, arrayOf(
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
@@ -533,6 +502,38 @@ abstract class CommonJavaScriptInterface(
                 ), 1
             )
         }
+        // For Android >= 10, use scoped storage via SimpleStorage library to get the permission to write files in a folder
+        // For Android < 10, SimpleStorage serves as a simple folder path picker, so that we still save where the user want look for a database file
+        // Note that SimpleStorage takes care of all the gritty technical details, including whether the user must pick a root path BEFORE selecting the folder they want to store in, everything is explained to the user
+        Log.d("SuperProductivity", "Before SimpleStorageHelper callback func def")
+        // Register a callback with SimpleStorage when a folder is picked
+        activity.storageHelper.onFolderSelected =
+            { requestCode, root -> // could also use simpleStorageHelper.onStorageAccessGranted()
+                Log.d("SuperProductivity", "Success Folder Pick! Now saving...")
+                // Get absolute path to folder
+                val fpath = root.getAbsolutePath(activity)
+                // Open preferences to save folder to path
+                val sp = activity.getPreferences(Context.MODE_PRIVATE)
+                sp.edit().putString("filesyncFolder", fpath).apply()
+                // Once permissions are granted, callback web application to continue execution
+                callJavaScriptFunction(
+                    FN_PREFIX + "grantFilePermissionCallBack('" + requestId + "')"
+                )
+            }
+        // Open folder picker via SimpleStorage, this will request the necessary scoped storage permission
+        // Note that even though we get permissions, we need to only write DocumentFile files, not MediaStore files, because the latter are not meant to be reopened in the future so we can lose permission at anytime once they are written once, see: https://github.com/anggrayudi/SimpleStorage/issues/103
+        Log.d("SuperProductivity", "Get Storage Access permission")
+        activity.storageHelper.openFolderPicker(
+            // We could also use simpleStorageHelper.requestStorageAccess()
+            initialPath = FileFullPath(
+                activity,
+                StorageId.PRIMARY,
+                "SupProd"
+            ), // SimpleStorage.externalStoragePath if we want to default to sdcard
+            // to force pick a specific folder and none others, use these arguments for simpleStorageHelper.requestStorageAccess():
+            //expectedStorageType = StorageType.EXTERNAL,
+            //expectedBasePath = "SupProd"
+        )
     }
 
     protected fun callJavaScriptFunction(script: String) {

--- a/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/FullscreenActivity.kt
@@ -85,7 +85,7 @@ class FullscreenActivity : AppCompatActivity() {
             Toast.makeText(this, "DEBUG: $url", Toast.LENGTH_SHORT).show()
             webView.clearCache(true)
             webView.clearHistory()
-            WebView.setWebContentsDebuggingEnabled(true);
+            WebView.setWebContentsDebuggingEnabled(true); // necessary to enable chrome://inspect of webviews on physical remote Android devices, but not for AVD emulator, as the latter automatically enables debug build features
         } else {
             url = "https://app.super-productivity.com"
         }

--- a/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
@@ -117,7 +117,9 @@ class KeepAliveNotificationService : Service() {
         if (message == "") {
             builder.setContentText(null)
         }
-        notificationManager.notify(NOTIFY_ID, builder.build())
+        if (::notificationManager.isInitialized) {
+            notificationManager.notify(NOTIFY_ID, builder.build())
+        }
     }
 
     private fun startForeground() {
@@ -131,8 +133,10 @@ class KeepAliveNotificationService : Service() {
                 importance
             )
             channel.description = description
-            notificationManager = getSystemService(NotificationManager::class.java)
-            notificationManager.createNotificationChannel(channel)
+            if (::notificationManager.isInitialized) {
+                notificationManager = getSystemService(NotificationManager::class.java)
+                notificationManager.createNotificationChannel(channel)
+            }
 
             // create notification
             val notificationIntent = Intent(this, FullscreenActivity::class.java)

--- a/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
@@ -117,7 +117,7 @@ class KeepAliveNotificationService : Service() {
         if (message == "") {
             builder.setContentText(null)
         }
-        if (::notificationManager.isInitialized) {
+        if (::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes
             notificationManager.notify(NOTIFY_ID, builder.build())
         }
     }
@@ -133,7 +133,7 @@ class KeepAliveNotificationService : Service() {
                 importance
             )
             channel.description = description
-            if (::notificationManager.isInitialized) {
+            if (::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes
                 notificationManager = getSystemService(NotificationManager::class.java)
                 notificationManager.createNotificationChannel(channel)
             }

--- a/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/KeepAliveNotificationService.kt
@@ -117,7 +117,7 @@ class KeepAliveNotificationService : Service() {
         if (message == "") {
             builder.setContentText(null)
         }
-        if (::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1 || ::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes, but for higher Android versions, checking causes a crash so we just pass
             notificationManager.notify(NOTIFY_ID, builder.build())
         }
     }
@@ -133,7 +133,7 @@ class KeepAliveNotificationService : Service() {
                 importance
             )
             channel.description = description
-            if (::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1 || ::notificationManager.isInitialized) { // check if lateinit object is initialized, avoids Android <= 7.1 crashes, but for higher Android versions, checking causes a crash so we just pass
                 notificationManager = getSystemService(NotificationManager::class.java)
                 notificationManager.createNotificationChannel(channel)
             }


### PR DESCRIPTION
# Description

Filesync compatibility with Android <= 9, plus some critical bugfixes.

Debug APK: https://github.com/lrq3000/super-productivity-android/releases/tag/super-productivity-android_scoped-storage-filesync_bugfix4

## Issues Resolved

* Fixes #36.
* Critical bugfixes for Android <= 7.1.1 and 13 (prevents crashes on startup due to notifications)

## Check List

Tested on:
- [x] Android 6.0 (SDK API 23, minimum targeted SDK version by `super-productivity-android` app) - could not test because could not update Chrome (no Google Play)
- [x] Android 7.0 (AVD emulator, updated Chrome)
- [x] Android 7.1.1 (AVD emulator, updated Chrome)
- [x] Android 8.0 (AVD emulator, updated Chrome)
- [x] Android 8.1 (AVD emulator, out-of-the-box Chrome)
- [x] Android 9 (AVD emulator, out-of-the-box Chrome)
- [x] Android 10 (AVD emulator)
- [x] Android 11 (AVD emulator)
- [x] Android 13 (AVD emulator)
- [x] Android 10 (Real device) + Windows 10 bidirectional sync.

Note that all the tests were done on a local copy of `super-productivity` webapp synced to the latest git commit, so I could test that the `allowedFolderPath()` was called and displayed correctly on the UI.