### PR TITLE
fix headers being formatted incorrectly

### DIFF
--- a/app/src/main/java/com/superproductivity/superproductivity/JavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/JavaScriptInterface.kt
@@ -245,14 +245,12 @@ class JavaScriptInterface(
                 out.close()
             }
             connection.headerFields.entries.forEach { entry ->
-                val output = buildString {
-                    entry.value.forEach {
-                        append(",$it")
-                    }
-                }
+                val output = entry.value.joinToString(separator = ", ")
+
                 // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2
                 try {
-                    headers.put(entry.key.lowercase(Locale.ROOT), output)
+                    if (entry.key != null)
+                        headers.put(entry.key.lowercase(Locale.ROOT), output)
                 } catch (e: JSONException) {
                     e.printStackTrace()
                 }


### PR DESCRIPTION
# Description

`URLConnection.getHeaderFields` counts the first line of the HTTP protocol as a header which is not true. By filtering only non-null keys we will grab the actual headers.

This PR depends on https://github.com/johannesjo/super-productivity/pull/2563

## Issues Resolved

List any existing issues this PR resolves https://github.com/johannesjo/super-productivity/issues/2548

BTW, I made this which would probably be useful for anyone that is going to try debugging on android.
```kotlin
    @Suppress("unused")
    @JavascriptInterface
    fun consoleLog(s: String) {
        Log.d("TW", "consoleLog: $s")
    }
```

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
