### PR TITLE
fix(Issue #49): refine notification display logic for consistent title and body presentation across devices

### DIFF
--- a/app/src/main/java/com/superproductivity/superproductivity/JavaScriptInterface.kt
+++ b/app/src/main/java/com/superproductivity/superproductivity/JavaScriptInterface.kt
@@ -156,12 +156,19 @@ class JavaScriptInterface(
             0
         }
         val pendingIntent = PendingIntent.getActivity(activity, 0, ii, pendingIntentFlags)
+
+        // Title
+        mBuilder.setContentTitle(title)
         val bigText: NotificationCompat.BigTextStyle = NotificationCompat.BigTextStyle()
         bigText.setBigContentTitle(title)
+
+        // Body
         if (body.isNotEmpty() && body.trim() != "undefined") {
+            mBuilder.setContentText(body)
             bigText.bigText(body)
         }
 
+        mBuilder.setStyle(bigText)
         mBuilder.setContentIntent(pendingIntent)
         mBuilder.setSmallIcon(R.mipmap.ic_launcher)
         mBuilder.setLargeIcon(
@@ -171,7 +178,6 @@ class JavaScriptInterface(
         )
         mBuilder.setSmallIcon(R.drawable.ic_stat_sp)
         mBuilder.priority = Notification.PRIORITY_MAX
-        mBuilder.setStyle(bigText)
         mBuilder.setAutoCancel(true)
 
         val mNotificationManager =


### PR DESCRIPTION
    - Added explicit `setContentTitle(title)` and `setContentText(body)` to ensure both the title and body are consistently displayed in both collapsed and expanded views.
    - Retained the use of `BigTextStyle` and `setBigContentTitle(title)` to maintain consistent title display when notifications are expanded.

    These changes resolve previous inconsistencies on Xiaomi and other Android devices, ensuring that notifications display both the title and body as expected.